### PR TITLE
A few incremental fixes

### DIFF
--- a/VaultToGit.py
+++ b/VaultToGit.py
@@ -182,8 +182,51 @@ for x in range(startVersion, loopLength, 1):
     os.system("git gc")
     os.system(git_commit)
 
-    clearWorkingDir = "cd /D " + gitDestination_full + ' && git rm .'
-    os.system(clearWorkingDir)
+    if( x + 1 < loopLength ):
+        clearWorkingDir = "cd /D " + gitDestination_full + ' && git rm -r .'
+        os.system(clearWorkingDir)
+
+'''
+# jcairns 06162022: I'm leaving this in, just in case it still proves useful in
+# ths future, but I believe that the fix in the loop above to do a 'git rm -r .'
+# on all but the most recent commit obviates the need to check for and remove
+# any files or folders we have in our git repo that are not in the Vault tips.
+#
+# Remove anything not in the tips
+import tempfile
+import shutil
+
+bRemoved = False
+tipsdir = os.path.join( tempfile.gettempdir(), gitDestination )
+print( "Getting tips of Vault folder to " + tipsdir )
+getRepoCommand = "vault GETVERSION" + credentials +" -repository " + vaultRepo +" "+ commit_version + vaultFolder_full +" " + tipsdir
+os.system("cd /D " + SourceGearLocation + " && " + getRepoCommand)
+os.system("cd /D " + gitDestination_full)
+for filename in os.listdir(gitDestination_full.strip()):
+    if( filename.startswith( ".git" ) ):
+        continue
+    f = os.path.join(tipsdir, filename)
+    if( not os.path.exists( f ) ):
+        bRemoved = True
+        print( "FILE DOES NOT EXIST IN VAULT TIPS: " + filename )
+        print( "REMOVING FROM GIT" )
+        if( os.path.isdir( filename ) ):
+            os.system("git rm -r " + filename)
+        else:
+            os.system("git rm " + filename)
+            
+try:
+    print( "Deleting temporary Vault tips folder " + tipsdir )
+    shutil.rmtree(tipsdir)
+except OSError as e:
+    print("Error: %s : %s" % (tipsdir, e.strerror))
+            
+if( bRemoved ):
+    git_commit = "git commit" + ' --author '+'"'+ commit_user + '<'+ git_user_email +'>"' +" --date=" + '"'+ commit_date +'" ' +" -m Removed files and folders not present in the tips of the Vault folder"    
+    print('\n\n', git_commit, '\n\n')
+    os.system("git gc")
+    os.system(git_commit)    
+'''
 
 if (auto_pusher == 1):
     os.system("git push -u origin master")

--- a/strip_xml_entities.py
+++ b/strip_xml_entities.py
@@ -3,6 +3,42 @@
 import sys, re, codecs
 from optparse import OptionParser
 
+def strip_nested_quotation_marks( line ):
+    stripped_line = ""
+    cur_str = ""
+    tokens = ["<item version=\"", " date=\"", " user=\"", " comment=\"", " objverid=\"", " txid=\"", " />"]
+    i = 0
+
+    while( i < len( tokens ) - 1 ):
+        bCommentMissing = False
+        loc1 = line.find( tokens[i], 0, len( line ) )
+        loc2 = line.find( tokens[i + 1], 0, len( line ) )
+        
+        # Special handling for "comment" being optional
+        if( i == 2 and loc2 == -1 ):
+            loc2 = line.find( tokens[i + 2], 0, len( line ) )
+            bCommentMissing = True
+        
+        if( i == 0 and loc1 > -1 ):
+            stripped_line += line[0:loc1]
+
+        if( loc1 > -1 and loc2 > -1 ):
+            loc1 += len( tokens[i] )
+            cur_str = line[loc1:loc2 - 1]
+            cur_str = cur_str.replace( "\"", "" )
+            stripped_line += tokens[i] + cur_str + "\""
+        else:
+            break
+            
+        i += ( 2 if bCommentMissing else  1 )
+        
+        if( i >= len( tokens ) - 1 ):
+            stripped_line += line[loc2:len( line )]
+            return stripped_line
+            
+    return line
+            
+
 def strip_chars(f,f2,extra=u''):
     remove_re = re.compile(u'[\x00-\x08\x0B-\x0C\x0E-\x1F\x7F%s]' % extra)
     i = 1
@@ -15,6 +51,7 @@ def strip_chars(f,f2,extra=u''):
        if count > 0:
           plur = ((count > 1) and u's') or u''
           sys.stderr.write('Line %d, removed %s character%s.\n' % (i, count, plur))
+       new_line = strip_nested_quotation_marks( new_line )
        newf.write(new_line)
        stripped = stripped + count
        i = i + 1


### PR DESCRIPTION
In VaultToGit.py, updated the logic to clear the working dir to use
'git rm -r .' instead of 'git rm .' and, critically, to not do this on the final
loop iteration (i.e. leave the Vault tips as the final contents of the new git
repo).

In strip_xml_entities.py, added logic to strip nested quotation marks from the
XML attributes. There are certainly better ways of doing this. This is not
"XML-aware" logic and is therefore brittle, but I believe that to be okay since
the formatting of the attributes as they're pulled from Vault should be brittle
as well. It should also fail safe insofar as it will not modify a line at all
if it does not exactly match the format it expects.